### PR TITLE
Set token variables to sensitive

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -12,8 +12,9 @@ variable "sonar_token" {
 variable "gh_token" {
   description = "GitHub token"
   type        = string
+  sensitive   = true
 }
-# TF_VAR_gh_token
+# TF_VAR_gh_org
 variable "gh_org" {
   description = "GitHub Organization"
   type        = string
@@ -22,4 +23,5 @@ variable "gh_org" {
 variable "sonar_admin_token" {
   description = "SonarQube Admin Token"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
Will redact the sensitive values in the output of Terraform commands or log messages.

The .tfstate file will still leak the secret: https://github.com/hashicorp/terraform/issues/516

Probably need to use an external secret manager to handle that issue, ex. https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret, or https://developer.hashicorp.com/terraform/tutorials/secrets/secrets-vault